### PR TITLE
Add image_preview

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -73,3 +73,14 @@ $(function(){
     $(this).css({'background-color': '#f9d2a1', 'color': '#7b5115'});
   });
 });
+
+// 画像プレビュー機能
+$(function(){
+    $('#product_image').on('change', function (e) {
+      var reader = new FileReader();
+      reader.onload = function (e) {
+        $(".image").attr('src', e.target.result);
+      }
+      reader.readAsDataURL(e.target.files[0]);
+    });
+  });

--- a/app/views/owner/products/edit.html.erb
+++ b/app/views/owner/products/edit.html.erb
@@ -7,9 +7,7 @@
 		<div class="row">
 			<div class="col-xs-4">
 				<div class="product_image">
-					<%= attachment_image_tag(@product, :image, :fill, 100, 100 ) %>
-				</div>
-				<div class="image">
+					<%= attachment_image_tag(@product, :image, size: "100x100" ) %>
 					<%= f.attachment_field :image %>
 				</div>
 			</div>


### PR DESCRIPTION
画像プレビュー機能を追加しました。
owner_products_editのviewでは正常に動作していました。おそらく、他のviewでも、画像投稿ボタンと表示個所をproduct_imageのクラスで囲ってもらえば動作すると思われます。